### PR TITLE
Upgrade GDTImporter

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -70,7 +70,7 @@ grails.project.dependency.resolution = {
                 ":spring-security-core:1.1.2",
 
                 ":gdt:0.3.1",
-                ":gdtimporter:0.5.2",
+                ":gdtimporter:0.5.3",
 
                 ":famfamfam:1.0.1",
 


### PR DESCRIPTION
GDTImported now doesn't stall when no timepoint has been defined when importing samples (with subject references)
