### PR TITLE
Sample name: use sample type name instead of the sample template name.

### DIFF
--- a/grails-app/controllers/dbnp/studycapturing/StudyController.groovy
+++ b/grails-app/controllers/dbnp/studycapturing/StudyController.groovy
@@ -214,7 +214,7 @@ class StudyController {
 
         // Check the distinct templates for these entities, without loading all
         // entities for efficiency reasons
-        def templates = entityClass.executeQuery("select distinct s.template from " + entityClass.simpleName + " s WHERE s.parent = ?", [study ])
+        def templates = entityClass.executeQuery("select distinct s.template from " + entityClass.simpleName + " s WHERE s.parent = :study", [ study: study ] )
 
         [
             study: study,

--- a/local-plugins/dbxpBase/grails-app/domain/dbnp/studycapturing/Sample.groovy
+++ b/local-plugins/dbxpBase/grails-app/domain/dbnp/studycapturing/Sample.groovy
@@ -208,11 +208,11 @@ class Sample extends TemplateEntity {
 
             def subjectName = parentSubject.name
             def eventGroupName = parentSubjectEventGroup?.eventGroup?.name.replaceAll("([ ]{1,})", "")
-            def sampleTemplateName = parentEvent?.event.template?.name.replaceAll("([ ]{1,})", "")
+            def parentEventName = parentEvent.event.name
             if (grailsApplication.config.gscf.reCapitalizeSampleNames != "false") {
                 subjectName = ucwords(subjectName)
                 eventGroupName = ucwords(eventGroupName)
-                sampleTemplateName = ucwords(sampleTemplateName)
+                parentEventName = ucwords(parentEventName)
             }
 
 			def subjectEventGroupStartTime = parentSubjectEventGroup ? parentSubjectEventGroup.startTime : '0'
@@ -220,7 +220,7 @@ class Sample extends TemplateEntity {
 
 			def startTime = new RelTime( subjectEventGroupStartTime + samplingEventInstanceStartTime ).toString().replaceAll( " ", "" )
 
-			this.name = ( subjectName + "_" + eventGroupName + "_" + sampleTemplateName + "_" + startTime ).replaceAll( " ", "_" )
+			this.name = ( subjectName + "_" + eventGroupName + "_" + parentEventName + "_" + startTime ).replaceAll( " ", "_" )
 		}
 		return this.name
     }


### PR DESCRIPTION
Sample name generation: update in batch (50 times faster for 5000 samples).
Fixed deprecated Hql queries (positional parameter).